### PR TITLE
docs: add agent identity provenance standard

### DIFF
--- a/docs/process/AGENT_IDENTITY_AND_PROVENANCE.md
+++ b/docs/process/AGENT_IDENTITY_AND_PROVENANCE.md
@@ -1,0 +1,40 @@
+﻿# Agent Identity and Provenance
+
+## Identity
+
+- Agent GitHub account: dev-agent-shortgigs
+- Agent commit email: dev-agent@shortgigs.io
+- Repository: 
+shortgigs/usesteady-public
+
+## Scope
+
+- Permission level: write
+- Allowed path: feature branches + PR flow only
+- Protected branches: no direct writes
+
+## Human Responsibilities
+
+- review
+- approval
+- merge
+- governance ownership
+
+## Agent Restrictions
+
+- no admin access
+- no ruleset bypass
+- no repository settings or secrets access
+- no protected-branch direct writes
+
+## Verification Record
+
+- Provenance test branch: test/provenance-agent-identity
+- Provenance test date: 2026-04-22
+- Commit author verified as agent: yes
+- PR authority verified as human: yes
+- Branch protections verified unchanged: yes
+
+## Outcome
+
+- Status: ACTIVE


### PR DESCRIPTION
Adds repository-level machine-authorship and human-authority provenance standard.