### PR TITLE
chore(governance): seed public-repo trust surfaces -- CONTRIBUTING, SECURITY, issue templates (PR 2/4)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Report a reproducible bug in UseSteady public-facing behavior.
+title: "[bug] "
+labels:
+  - status/pending
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please include clear steps so the team can reproduce quickly.
+  - type: input
+    id: summary
+    attributes:
+      label: Short summary
+      description: One sentence describing the bug.
+      placeholder: Command fails with parse_error on valid replace input
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Include exact commands/input and expected order.
+      placeholder: |
+        1) Run ...
+        2) Enter ...
+        3) Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: The operation should complete and update file X.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: Got old_value_not_found even though text exists.
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS + shell + relevant versions.
+      placeholder: Windows 11, PowerShell, Node 20.x
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Propose a specific feature or product improvement.
+title: "[feature] "
+labels:
+  - status/pending
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please keep this request concrete and outcome-focused.
+  - type: input
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem are you trying to solve?
+      placeholder: I cannot automate batch edits safely in CI without ...
+    validations:
+      required: true
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed solution
+      description: Describe the desired behavior, not implementation details.
+      placeholder: Add a structured output mode that ...
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      placeholder: Current workaround is ...
+    validations:
+      required: false
+  - type: textarea
+    id: success
+    attributes:
+      label: Success criteria
+      description: How will we know this request is solved?
+      placeholder: I can run X flow with Y reliability.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/misuse_safety_issue.yml
+++ b/.github/ISSUE_TEMPLATE/misuse_safety_issue.yml
@@ -1,0 +1,48 @@
+name: Misuse or safety issue
+description: Report unsafe behavior, policy bypass risk, or misuse vector.
+title: "[safety] "
+labels:
+  - status/pending
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for safety concerns, abuse vectors, or policy bypass risks.
+        If urgent, include severity and immediate mitigation.
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - low
+        - medium
+        - high
+        - critical
+    validations:
+      required: true
+  - type: textarea
+    id: risk
+    attributes:
+      label: Risk summary
+      description: What could go wrong?
+      placeholder: This path may allow execution without explicit approval when ...
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction or trigger conditions
+      description: Include minimal reproducible steps if available.
+      placeholder: |
+        1) Configure ...
+        2) Trigger ...
+        3) Observe ...
+    validations:
+      required: false
+  - type: textarea
+    id: mitigation
+    attributes:
+      label: Suggested mitigation
+      placeholder: Fail closed when ... and surface clear blocking reason.
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to UseSteady
+
+Thanks for taking the time to engage with UseSteady. This is the public
+repository for friction reports, bug reports, feature requests, and
+safety issues. The CLI itself is published to npm; this repo exists so
+the conversation around it can be public, structured, and auditable.
+
+This document is short on purpose. It covers what we expect from
+contributions submitted here.
+
+## What this repo is for
+
+- **Friction reports** — anything in the CLI that felt confusing,
+  surprising, broken, or slower than it should be. Real friction is
+  more useful than polished bug reports.
+- **Bug reports** — reproducible defects in published behavior.
+- **Feature requests** — concrete proposals tied to a real workflow.
+- **Misuse / safety issues** — unsafe behavior, policy bypass risk, or
+  abuse vectors.
+
+Each of those has a dedicated issue template. Please use them. They
+exist because structured input gets triaged faster and gets more useful
+follow-up.
+
+## What UseSteady is, and how to keep proposals aligned
+
+UseSteady is a governed execution runtime. The principle, in one
+sentence:
+
+> AI proposes. The operator approves. The runtime enforces.
+
+Proposals that quietly weaken any of those three boundaries — letting
+AI act without explicit operator approval, replacing approval with
+heuristics, or moving enforcement out of the runtime — are unlikely to
+land. Proposals that strengthen the boundaries, surface them more
+clearly, or close gaps in them are very welcome.
+
+## Filing an issue
+
+When you open an issue, please:
+
+- Use the right template (`Bug report`, `Feature request`, or
+  `Misuse / safety issue`). Use `Misuse / safety issue` if you are
+  unsure whether something is a bug or a safety concern.
+- Keep the input verbatim. Do not paraphrase what UseSteady printed,
+  paste the exact text. Paraphrased output makes triage harder and
+  occasionally hides the actual defect.
+- Include version (e.g. `usesteady@0.1.0-alpha.NN`), OS, and shell.
+- For safety issues that you would not want public, please email
+  **founder@shortgigs.io** instead. See `SECURITY.md`.
+
+## Recognition
+
+We credit contributors in the public friction log when they opt in to
+public credit. That is the entire recognition program.
+
+We do not run a paid bounty, a tier system, points, or any other
+contributor compensation program. Reports are valued on their own
+merits, not on a payout schedule.
+
+## Conduct
+
+Be respectful. Disagree with claims, not people. Report conduct
+concerns to **founder@shortgigs.io**.
+
+## Encoding and formatting
+
+This repository is ASCII or UTF-8 without BOM. Please do not paste
+content with smart quotes, em-dash homoglyphs, or zero-width characters
+in titles, identifiers, or any operator-visible string. If your editor
+auto-converts quotes, please paste in a plain-text view first.
+
+## License
+
+UseSteady is Apache 2.0. By opening an issue or proposing a change you
+confirm that any text or content you submit can be used under the same
+license.
+
+## Code contributions
+
+The CLI source lives in a separate repository. If you want to propose
+a code change, open a friction report or feature request here first so
+the change has a public, citable starting point. Code-level
+contribution guidelines, the doctrine surface, and the rule registry
+live in that repository, not here.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+UseSteady's security guarantees come from architectural constraints —
+deny-by-default mutations, explicit operator approval, and a runtime
+that executes only what was approved. We treat any failure of those
+guarantees as a security issue.
+
+## How to report
+
+Send a private report to **founder@shortgigs.io** with:
+
+- A clear description of the issue.
+- The exact input or sequence that triggers it.
+- The observed behavior, including the version (e.g. `alpha.51`).
+- The expected behavior under the documented authority model.
+
+Please do not open public issues for security reports. We acknowledge
+receipt within 5 business days and follow up with a triage timeline.
+
+For non-sensitive safety concerns or possible misuse vectors that do
+not require private handling, the `Misuse / safety issue` template in
+this repository is also acceptable.
+
+## In scope
+
+The following are treated as security issues regardless of severity:
+
+- **Approval-gate bypass.** Any path that mutates the filesystem, the
+  working tree, or the workflow log without the operator approving the
+  exact step.
+- **Runtime drift from approval.** The runtime executing anything other
+  than what the operator approved.
+- **Identity-target spoofing.** A request acting on a different file,
+  path, or platform resource than the operator-visible identifier
+  suggests (Unicode confusables, normalization mismatches, bidirectional
+  overrides, homographs).
+- **Replay divergence.** A previously-recorded run replaying to a
+  different result than originally recorded.
+- **Secret leakage.** Credentials, tokens, or keys appearing in logs,
+  artifacts, error output, or any operator-visible surface.
+
+## Out of scope
+
+These are tracked as product issues, not security issues:
+
+- Bugs in the marketing site that do not expose secrets or user data.
+- Denial-of-service against a local CLI run on the operator's own
+  machine.
+- Abuse of third-party model providers (Anthropic, OpenAI, etc.) using
+  the operator's own credentials.
+- Behavior of unsupported runtimes (Node.js < 18, unsupported shells).
+- Performance and ergonomics issues.
+
+## What we will not do
+
+- We will not ask reporters to delay public disclosure beyond the
+  triage-and-fix window without an explicit reason.
+- We will not silently fix security issues. Every fix lands with a
+  changelog entry naming the class of failure and the affected versions.
+- We will not run a paid bug bounty, and we will not offer rewards in
+  exchange for a private report. Reporters who opt in are credited in
+  the public friction log; that is the recognition program.
+
+## Coordinated disclosure
+
+If you have already disclosed an issue publicly, please email us anyway
+so we can triage and respond in the same place reporters are looking.


### PR DESCRIPTION
## Summary

PR 2 of the CTO-locked four-PR governance rollout. Seeds this public repository's trust surfaces so submitters have a structured, predictable, and auditable place to engage with UseSteady.

**Locked PR sequence:**

1. governance surfaces (core repo) — landed as `shortgigs/usesteady-core#281`
2. **governance surfaces (public repo)** ← this PR
3. doctrine alignment + trust principles
4. contributor-program retirement + legal cleanup

**Locked posture for this repo:** *public repo = trust surface; core repo = implementation + governance depth*. This PR sticks to that boundary — it communicates governance posture, contribution posture, security posture, boundaries, and expectations. It does not communicate doctrine internals, eval claims, or internal governance mechanics; those stay in the core repo.

## What this PR adds

| File | Purpose |
|---|---|
| `CONTRIBUTING.md` | What this repo is for, how to file each kind of issue, the authority-model line as an externally-facing trust statement, recognition posture (opt-in public credit only — explicit no-paid-bounty / no-tier / no-points / no-compensation-program), encoding posture (ASCII or UTF-8 without BOM, no smart quotes / homoglyphs), Apache 2.0 license posture, conduct one-liner. Code contributions are explicitly redirected to the core repo with no internal-mechanics discussion on this surface. |
| `SECURITY.md` | Private report channel (founder@shortgigs.io), 5-business-day acknowledgement window, 5 in-scope security classes (approval-gate bypass, runtime drift from approval, identity-target spoofing, replay divergence, secret leakage) stated in user-facing language without internal architecture-doc cross-references, out-of-scope items, explicit no-paid-bounty / no-rewards-in-exchange-for-private-reports posture, coordinated disclosure clause. |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Structured intake for reproducible bugs. Auto-applies `status/pending` for friction-log read-model consistency. |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | Structured intake for feature proposals (problem, proposed solution, alternatives, success criteria). Auto-applies `status/pending`. |
| `.github/ISSUE_TEMPLATE/misuse_safety_issue.yml` | Structured intake for non-private safety / misuse concerns (severity, risk, reproduction, mitigation). Private-channel option referenced from `SECURITY.md`. Auto-applies `status/pending`. |

5 new files, 292 insertions, 0 deletions, 0 existing files modified.

## Doctrine alignment (in scope)

`CONTRIBUTING.md` adopts the locked authority-model line:

> AI proposes. The operator approves. The runtime enforces.

Used here as a public-facing trust statement (bounded, operational, auditable, non-magical). PR 3 will align the rest of the doctrine surface, including the README's positioning text, to match.

## Recognition posture (in scope)

Both new govdocs state the locked CTO recognition stance explicitly and consistently:

- *(`CONTRIBUTING.md`)* "We do not run a paid bounty, a tier system, points, or any other contributor compensation program. Reports are valued on their own merits, not on a payout schedule."
- *(`SECURITY.md`)* "We will not run a paid bug bounty, and we will not offer rewards in exchange for a private report. Reporters who opt in are credited in the public friction log; that is the recognition program."

## What this PR deliberately does NOT do

- Does **not** modify `README.md`. The README's positioning ("AI can propose changes. You approve before they run.") is close to but not identical with the locked doctrine line; aligning it belongs in **PR 3**, not in a public-surface governance PR.
- Does **not** add a `LICENSE` file even though the README declares Apache 2.0. License-file addition is a separate decision and not on the locked PR 2 scope.
- Does **not** add `CODE_OF_CONDUCT.md`. Conduct expectations are stated inline in `CONTRIBUTING.md` to keep the public surface thinner; a full code of conduct can be added later if the community grows to the point where it is operationally needed.
- Does **not** carry over the core-repo `CONTRIBUTING.md` mechanics: planner/compiler/runtime/extension authority-model details, the 4-question PR-hygiene checklist, or the `docs/architecture/` / `docs/doctrine/` / `docs/rules/` / `docs/adr/` taxonomy. Those are core-repo internals.
- Does **not** carry over the core-repo `SECURITY.md` cross-references to `CONTEXT_GATE.md`, `PLATFORM_PROJECT_CONTEXT_POLICY.md`, or `TRUTH_ARBITRATION.md`. Those are internal architecture documents and do not belong on the public trust surface.
- Does **not** add the eval harness (`eval/subq-harness/`). Experimental and internal; stays in the core repo.
- Does **not** touch `.github/workflows/repo-validation.yml`, the existing CI signal job. PR 2 is governance-surface only.
- Does **not** change any issue labels or label policy.

## Doctrine reference

Layer/rule touched: governance documentation only. No code, no runtime, no labels, no CI, no automation.

## Behavior change

None. Pure governance documentation + structured issue intake templates.

## Replay impact

None.

## Tests

Not applicable — this PR adds documentation and issue templates only. The repo's existing `Repo validation` CI job (minimal repo-shape check, no merge markers) will run automatically on this PR.

## Verification

- 5 files staged; 0 existing files modified.
- Sweep of staged govdocs for payout/reward/tier/paid/bounty/points/payment/incentive language returned 3 hits, all of which are explicit anti-payout statements aligned with the locked CTO direction.
- Sweep of staged `ISSUE_TEMPLATE/*.yml` files for the same vocabulary returned 0 hits.
- README.md untouched (intentional — that's PR 3's job).

## Out-of-scope follow-ups (tracked, not done here)

- **PR 3:** doctrine alignment + trust principles — align README positioning, propagate the locked doctrine line across surfaces, align core doctrine corpus, relocate `MODEL_INSERTION_POLICY.md` to `docs/doctrine/` in the core repo.
- **PR 4:** contributor-program retirement — remove public payout/reward language, tier visuals, payout-oriented SEO/metadata, "Get paid" framing on the marketing site + legal cleanup (honor reports submitted before merge date of PR 4 under terms in effect at submission).
- **Future governance-surface PR (this repo):** `LICENSE` file, `CODE_OF_CONDUCT.md`, PR template if/when public code contributions start being routed through this repo.

## Test plan

- [ ] CI green on this PR (`Repo validation` job).
- [ ] Reviewer confirms the doctrine line in `CONTRIBUTING.md` matches the locked CTO line exactly.
- [ ] Reviewer confirms recognition posture in `CONTRIBUTING.md` and `SECURITY.md` matches the locked CTO direction (no paid bounty, no tier, no points, opt-in public credit only).
- [ ] Reviewer confirms README, LICENSE, and any pre-existing files are untouched.
- [ ] Reviewer confirms no internal architecture-doc cross-references leaked into `SECURITY.md`.
- [ ] Manual: open `Bug report`, `Feature request`, and `Misuse / safety issue` templates from the GitHub UI to confirm the forms render and `status/pending` is auto-applied.
