### PR TITLE
chore(infra): restore .github/workflows/repo-validation.yml on main

### DIFF
--- a/.github/workflows/repo-validation.yml
+++ b/.github/workflows/repo-validation.yml
@@ -1,0 +1,31 @@
+name: Repo validation
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  repo-validation:
+    name: Repo validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate minimal repository shape
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f README.md
+          test -s README.md
+
+      - name: Fail on unresolved merge markers
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- . >/dev/null; then
+            echo "Unresolved merge conflict markers found."
+            exit 1
+          fi


### PR DESCRIPTION
## Why

`main` branch protection requires the `Repo validation` status check
(`enforce_admins: true`, `required_signatures: true`), but the workflow
file that produces it has been **absent from `main` since ~2026-04-23**.
The workflow's last successful runs (~2026-04-19) were on a temporary
branch (`chore/signal-readme-touch-public`, SHA `1bf2b1e2`); the file
was never carried back to `main`.

Net effect: **the repo has been merge-frozen for ~13 days.** No PR can
satisfy branch protection because no workflow is producing the required
check. PR #63 (`chore/governance-surfaces-public`) is the open PR
currently held by this drift, but the block is repo-wide, not
#63-specific.

This is the kind of trust-debt the recent
[`shortgigs/usesteady-core`](https://github.com/shortgigs/usesteady-core)
correction cycle was about (#283 / #284 / #285 — messaging truth, data
truth, deploy-channel truth). The chosen fix is **truthful operational
convergence, not a bypass**: restore the missing workflow, preserve
`enforce_admins`, preserve `required_signatures`, satisfy the
protection rule rather than weaken it.

## What this PR does

Adds **one file**:

```
.github/workflows/repo-validation.yml
```

Restored **byte-for-byte** from the historical SHA where it last ran
successfully (`1bf2b1e2`). Blob SHA is
`4a9352ca4352bfa981c36e8b0a45308c054cf814` — identical to the
historical blob (verified via
`gh api repos/shortgigs/usesteady-public/git/trees/1bf2b1e2...`).

The workflow's two steps are unchanged from history:

1. **Validate minimal repository shape** — asserts `README.md` exists
   and is non-empty.
2. **Fail on unresolved merge markers** — `git grep` for `<<<<<<<` /
   `=======` / `>>>>>>>` anywhere in the tree and fails the run if
   any are found.

Trigger: `pull_request` against `main` only. Permissions:
`contents: read`.

## What this PR explicitly does NOT do

Per the scope lock for this restoration:

- **No CI expansion.** No new validation steps, no markdown lint, no
  link check, no encoding sweep, no spelling, no anything else.
- **No workflow redesign.** No permissions changes, no concurrency
  group, no caching, no runner change, no schedule trigger, no
  workflow_dispatch.
- **No branch-protection edits.** The protection rule is already
  correct. This PR satisfies the rule by restoring the missing
  workflow, not by weakening the rule.
- **No bundled governance work.** No README edits, no LICENSE, no
  CODE_OF_CONDUCT, no issue templates, no SECURITY.md, no
  CONTRIBUTING.md, no anything that lives in PR #63 or any other
  in-flight surface. Those land in their own PRs.
- **No drift-root-cause analysis.** That's tracked separately if
  needed; this PR is purely the operational unblock.

## Verification

- ✅ Commit signature **verified** server-side
  (`verified: true, reason: valid`, SSH key).
- ✅ Restored blob SHA matches historical exactly
  (`4a9352ca4352bfa981c36e8b0a45308c054cf814`).
- ✅ Self-check: this PR's own `Repo validation` run should pass
  (`README.md` is present and non-empty; no merge markers in the
  tree). If the workflow's first run on this PR fails, that
  immediately surfaces a real problem rather than masking it.

## After merge

1. Merge this PR.
2. Rebase PR #63 against the new `main`. `Repo validation` will run
   on it normally.
3. Approve and merge PR #63 through the standard branch-protection
   contract.
4. Repo is back at a converged steady state.

## Refs

- Historical SHA where the workflow last ran: `1bf2b1e2`
- Branch protection (unchanged): `main` requires `Repo validation`,
  `enforce_admins: true`, `required_signatures: true`,
  `required_pull_request_reviews.required_approving_review_count: 1`.
- Held PR: #63 (governance surfaces — `CONTRIBUTING.md`,
  `SECURITY.md`, issue templates).

Made-with: Cursor
